### PR TITLE
Adapt RefreshTokenProvider for changes in Symfony 5.3

### DIFF
--- a/Security/Provider/RefreshTokenProvider.php
+++ b/Security/Provider/RefreshTokenProvider.php
@@ -67,22 +67,22 @@ class RefreshTokenProvider implements UserProviderInterface
     {
         if (null !== $this->customUserProvider) {
             if (method_exists($this->customUserProvider, 'loadUserByIdentifier')) {
-                return $this->customUserProvider->loadUserByIdentifier($username);
+                return $this->customUserProvider->loadUserByIdentifier($identifier);
             }
 
-            return $this->customUserProvider->loadUserByUsername($username);
+            return $this->customUserProvider->loadUserByUsername($identifier);
         }
 
         if (class_exists(InMemoryUser::class)) {
             return new InMemoryUser(
-                $username,
+                $identifier,
                 null,
                 ['ROLE_USER']
             );
         }
 
         return new User(
-            $username,
+            $identifier,
             null,
             ['ROLE_USER']
         );

--- a/spec/Security/Provider/RefreshTokenProviderSpec.php
+++ b/spec/Security/Provider/RefreshTokenProviderSpec.php
@@ -4,9 +4,12 @@ namespace spec\Gesdinet\JWTRefreshTokenBundle\Security\Provider;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class RefreshTokenProviderSpec extends ObjectBehavior
@@ -19,7 +22,7 @@ class RefreshTokenProviderSpec extends ObjectBehavior
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider');
+        $this->shouldHaveType(RefreshTokenProvider::class);
     }
 
     public function it_gets_username($refreshToken, $refreshTokenManager)
@@ -41,6 +44,11 @@ class RefreshTokenProviderSpec extends ObjectBehavior
         $this->loadUserByUsername('testname');
     }
 
+    public function it_loads_by_identifier()
+    {
+        $this->loadUserByIdentifier('testname');
+    }
+
     public function it_refresh_user(UserInterface $user)
     {
         $this->shouldThrow(new UnsupportedUserException())->duringRefreshUser($user);
@@ -48,6 +56,10 @@ class RefreshTokenProviderSpec extends ObjectBehavior
 
     public function it_supports_class()
     {
-        $this->supportsClass('Symfony\Component\Security\Core\User\User')->shouldBe(true);
+        if (class_exists(InMemoryUser::class)) {
+            $this->supportsClass(InMemoryUser::class)->shouldBe(true);
+        }
+
+        $this->supportsClass(User::class)->shouldBe(true);
     }
 }


### PR DESCRIPTION
The `symfony/security-core` package has some changes that should be accounted for in the `RefreshTokenProvider` class:

- `UserProviderInterface` soft-adds a new `loadUserByIdentifier()` method, this will be required in Symfony 6
- `UserProviderInterface` deprecates the `loadUserByUsername()` method, this will be removed in Symfony 6
- The `Symfony\Component\Security\Core\User\User` class is deprecated in Symfony 5.3 and will be removed in Symfony 6, `Symfony\Component\Security\Core\User\InMemoryUser` should be used instead

The provider is updated to use the newer API when available and falls back to the legacy API in all other cases.