### PR TITLE
Fix method signature

### DIFF
--- a/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
@@ -62,7 +62,7 @@ use Symfony\Component\DependencyInjection\Reference;
     /**
      * @return string
      */
-    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): array|string
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): string
     {
         $authenticatorId = 'security.authenticator.refresh_jwt.'.$firewallName;
 

--- a/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
@@ -62,7 +62,7 @@ use Symfony\Component\DependencyInjection\Reference;
     /**
      * @return string
      */
-    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId)
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): array|string
     {
         $authenticatorId = 'security.authenticator.refresh_jwt.'.$firewallName;
 


### PR DESCRIPTION
Solves the following issue: "Declaration of Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Security\Factory\RefreshTokenAuthenticatorFactory::createAuthenticator(Symfony\Component\DependencyInjection\ContainerBuilder $container, string $firewallName, array $config, string $userProviderId) must be compatible with Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface::createAuthenticator(Symfony\Component\DependencyInjection\ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): array|string"